### PR TITLE
Proxy cleanup

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -338,10 +338,12 @@ impl BlendEngine {
             [vk::WriteDescriptorSet::image_view(0, background.clone())],
         )?;
         if clear_background {
-            // Hmmm... The clearing of the whole image kinda breaks the contract, but not
-            // much for me to do :V
+            use vulkano::image::ImageViewAbstract;
             commands.clear_color_image(vk::ClearColorImageInfo {
                 clear_value: [0.0;4].into(),
+                regions: smallvec::smallvec![
+                    background.subresource_range().clone(),
+                ],
                 ..vulkano::command_buffer::ClearColorImageInfo::image(background.image().clone())
             })?;
         }

--- a/src/document_viewport_proxy.rs
+++ b/src/document_viewport_proxy.rs
@@ -1,5 +1,17 @@
 use crate::*;
 
+/// Proxy called into by the window renderer to perform the necessary synchronization and such to render the screen
+/// behind the Egui content.
+pub trait PreviewRenderProxy {
+    /// Create the render commands for this frame. Assume used resources are borrowed until a matching "render_complete" for this
+    /// frame idx is called.
+    fn render(&self, swapchain_image_idx: u32) -> AnyResult<Arc<vk::PrimaryAutoCommandBuffer>>;
+
+    /// When the future of a previous render has completed
+    fn render_complete(&self, idx: u32);
+    fn surface_changed(&self, render_surface: &render_device::RenderSurface);
+}
+
 mod shaders {
     pub mod vertex {
         vulkano_shaders::shader! {
@@ -47,6 +59,7 @@ mod shaders {
                 vec3 grid_color = vec3(vec3(is_light ? LIGHT : DARK));
 
                 vec4 col = texture(image, uv);
+                // col is pre-multiplied, grid color is not. Combine!
                 color = vec4(grid_color * (1.0 - col.a) + col.rgb, 1.0);
             }"
         }
@@ -54,20 +67,87 @@ mod shaders {
 }
 
 /// An acquired image from the proxy. Will become the current image when dropped,
-/// after a user-provided GPU future.
-struct DocumentViewportPreviewProxyGuard {
+/// or after a user-provided GPU fence.
+pub struct DocumentViewportPreviewProxyImageGuard<'proxy> {
+    proxy: &'proxy DocumentViewportPreviewProxy,
+    image: Arc<vk::ImageView<vk::StorageImage>>,
+    is_submitted: bool,
+}
+impl DocumentViewportPreviewProxyImageGuard<'_> {
+    /// Submit this image for display immediately. The image should be done writing by the device, as it
+    /// will be used for reading without synchronizing!
+    pub fn submit_now(self) {
+        // mwehehehehe. sneaky delegate to Drop::drop >:3
+    }
+    /// Submit this image for display, after the given fence finishes. The image should be done writing
+    /// at the time of the fence, as it will be used for reading as soon as the fence is signalled.
+    pub fn submit_with_fence(
+        mut self,
+        fence: vk::sync::future::FenceSignalFuture<Box<dyn GpuFuture + Send>>,
+    ) {
+        // Surpress default drop behavior.
+        self.is_submitted = true;
 
+        // Place this fence within the proxy.
+        let mut write = self.proxy.swap_after.write().unwrap();
+        // This should not be possible - if this proxy exists, there should have been no
+        // outstanding writes waiting.
+        assert!(write.is_empty());
+        *write = SwapAfter::Fence(fence);
+    }
+}
+impl Drop for DocumentViewportPreviewProxyImageGuard<'_> {
+    fn drop(&mut self) {
+        if self.is_submitted {
+            return;
+        }
+        self.is_submitted = true;
+        // Place an immediate swap into the proxy.
+        let mut write = self.proxy.swap_after.write().unwrap();
+        // This should not be possible - if this proxy exists, there should have been no
+        // outstanding writes waiting.
+        assert!(write.is_empty());
+        *write = SwapAfter::Now;
+    }
+}
+impl std::ops::Deref for DocumentViewportPreviewProxyImageGuard<'_> {
+    type Target = Arc<vk::ImageView<vk::StorageImage>>;
+    fn deref(&self) -> &Self::Target {
+        &self.image
+    }
+}
+
+enum SwapAfter<Future: GpuFuture> {
+    Fence(vk::sync::future::FenceSignalFuture<Future>),
+    Now,
+    Empty,
+}
+impl<Future: GpuFuture> SwapAfter<Future> {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Empty => true,
+            _ => false,
+        }
+    }
 }
 
 /// An double-buffering interface between the asynchronous edit->render pipeline of documents
 /// and the synchronous redrawing of the many swapchain images.
 /// (Because dealing with one image is easier than potentially many, as we don't care about excess framerate)
+/// Provides a method to get a drawable buffer asynchronously, and handles drawing that to the screen
+/// whenever needed by the swapchain.
 pub struct DocumentViewportPreviewProxy {
     render_context: Arc<render_device::RenderContext>,
 
     document_images: [Arc<vk::ImageView<vk::StorageImage>>; 2],
     document_image_bindings: [Arc<vk::PersistentDescriptorSet>; 2],
 
+    /// After this fence is completed, a swap occurs.
+    /// If this is not none, it implies both buffers are in use.
+    swap_after: std::sync::RwLock<SwapAfter<Box<dyn GpuFuture + Send>>>,
+    /// A buffer is available for writing if this notify is set.
+    write_ready_notify: tokio::sync::Notify,
+    /// Which buffer is the swapchain reading from?
     read_buf: std::sync::atomic::AtomicU8,
 
     render_pass: Arc<vk::RenderPass>,
@@ -228,7 +308,9 @@ impl DocumentViewportPreviewProxy {
             document_to_preview_matrix: document_to_preview_matrix,
             viewport_dimensions: size,
 
+            swap_after: SwapAfter::Empty.into(),
             read_buf: 0.into(),
+            write_ready_notify: Default::default(),
 
             document_images: document_image_views,
             document_image_bindings,
@@ -341,30 +423,67 @@ impl DocumentViewportPreviewProxy {
             }
         }
     }
-    pub async fn get_writeable_buffer(&self) -> Arc<vk::ImageView<vk::StorageImage>> {
-        //Todo - wait for rendering on this image to complete.
-        self.document_images
-            [(self.read_buf.load(std::sync::atomic::Ordering::Acquire) ^ 1) as usize]
-            .clone()
+    /// Internal use only. After the user's buffer is deemed swappable, the read index in switched over and returned.
+    /// Furthermore, the old read buffer is signalled as being writable to any waiting users. New read idx is returned.
+    fn swap(&self) -> usize {
+        // Unsure of the proper ordering here. It's not the hottest path, so the strictest one should be okeyyyy.
+        let idx = self
+            .read_buf
+            .fetch_xor(1, std::sync::atomic::Ordering::SeqCst) as usize;
+        self.write_ready_notify.notify_one();
+        idx
     }
-    pub fn swap(&self) {
-        self.read_buf
-            .fetch_xor(0x01, std::sync::atomic::Ordering::Release);
+    /// Read the proxy - returns the index of the current read buffer. Internally swaps if a render is complete.
+    /// A call to `read` implies the last use of the read image is complete. This must be synchronized externally!!
+    pub unsafe fn read(&self) -> usize {
+        let mut lock = self.swap_after.write().unwrap();
+        match &*lock {
+            // Nothin to do
+            SwapAfter::Empty => self.read_buf.load(std::sync::atomic::Ordering::SeqCst) as usize,
+            // Immediate swap
+            SwapAfter::Now => {
+                *lock = SwapAfter::Empty;
+                self.swap()
+            }
+            // Swap if the fence is signalled - without waiting. If not, do nothing.
+            SwapAfter::Fence(fence) => {
+                if fence.is_signaled().unwrap() {
+                    *lock = SwapAfter::Empty;
+                    self.swap()
+                } else {
+                    self.read_buf.load(std::sync::atomic::Ordering::SeqCst) as usize
+                }
+            }
+        }
+    }
+    pub async fn write(&self) -> DocumentViewportPreviewProxyImageGuard<'_> {
+        self.write_ready_notify.notified().await;
+        assert!(self.swap_after.read().unwrap().is_empty());
+        // We are now the sole writer. Hopefully. Return the proxy:
+        DocumentViewportPreviewProxyImageGuard {
+            // Return whichever image is *not* the read buf. Uhm uh ordering??
+            image: self.document_images
+                [(self.read_buf.load(std::sync::atomic::Ordering::SeqCst) ^ 1) as usize]
+                .clone(),
+            is_submitted: false,
+            proxy: &self,
+        }
     }
     pub fn get_matrix(&self) -> cgmath::Matrix4<f32> {
         self.document_to_preview_matrix
     }
 }
-impl crate::PreviewRenderProxy for DocumentViewportPreviewProxy {
-    fn render<'a>(&'a mut self, idx: u32) -> AnyResult<Arc<vk::PrimaryAutoCommandBuffer>> {
+impl PreviewRenderProxy for DocumentViewportPreviewProxy {
+    fn render(&self, idx: u32) -> AnyResult<Arc<vk::PrimaryAutoCommandBuffer>> {
         let Some(buffer) = self.prerecorded_command_buffers.get(idx as usize) else {
             anyhow::bail!("No buffer found for swapchain image {idx}!")
         };
 
-        Ok(buffer[self.read_buf.load(std::sync::atomic::Ordering::Acquire) as usize].clone())
+        // Uh
+        Ok(buffer[unsafe { self.read() }].clone())
     }
-    fn render_complete(&mut self, _idx: u32) {}
-    fn surface_changed(&mut self, render_surface: &render_device::RenderSurface) {
+    fn render_complete(&self, _idx: u32) {}
+    fn surface_changed(&self, render_surface: &render_device::RenderSurface) {
         if render_surface.context().device() != self.pipeline.device() {
             panic!("Wrong device used to recreate preview proxy!")
         }

--- a/src/document_viewport_proxy.rs
+++ b/src/document_viewport_proxy.rs
@@ -53,14 +53,15 @@ mod shaders {
     }
 }
 
-#[derive(vk::Vertex, bytemuck::Pod, bytemuck::Zeroable, Clone, Copy)]
-#[repr(C)]
-struct DocumentVertex {
-    #[format(R32G32_SFLOAT)]
-    pos: [f32; 2],
+/// An acquired image from the proxy. Will become the current image when dropped,
+/// after a user-provided GPU future.
+struct DocumentViewportPreviewProxyGuard {
+
 }
 
-//type AnyFence = vk::sync::future::FenceSignalFuture<Box<dyn vk::sync::GpuFuture>>;
+/// An double-buffering interface between the asynchronous edit->render pipeline of documents
+/// and the synchronous redrawing of the many swapchain images.
+/// (Because dealing with one image is easier than potentially many, as we don't care about excess framerate)
 pub struct DocumentViewportPreviewProxy {
     render_context: Arc<render_device::RenderContext>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1028,23 +1028,11 @@ impl Globals {
 }
 static GLOBALS: std::sync::OnceLock<Globals> = std::sync::OnceLock::new();
 
-/// Proxy called into by the window renderer to perform the necessary synchronization and such to render the screen
-/// behind the Egui content.
-pub trait PreviewRenderProxy {
-    /// Create the render commands for this frame. Assume used resources are borrowed until a matching "render_complete" for this
-    /// frame idx is called.
-    fn render(&mut self, swapchain_image_idx: u32) -> AnyResult<Arc<vk::PrimaryAutoCommandBuffer>>;
-
-    /// When the future of a previous render has completed
-    fn render_complete(&mut self, idx: u32);
-    fn surface_changed(&mut self, render_surface: &render_device::RenderSurface);
-}
-
 fn listener(
     mut event_stream: tokio::sync::broadcast::Receiver<stylus_events::StylusEventFrame>,
     renderer: Arc<render_device::RenderContext>,
     document_preview: Arc<
-        parking_lot::RwLock<document_viewport_proxy::DocumentViewportPreviewProxy>,
+        document_viewport_proxy::DocumentViewportPreviewProxy,
     >,
 ) -> AnyResult<()> {
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1084,7 +1072,7 @@ fn listener(
         loop {
             match event_stream.recv().await {
                 Ok(event_frame) => {
-                    let matrix = { document_preview.read().get_matrix() }.invert().unwrap();
+                    let matrix = document_preview.get_matrix().invert().unwrap();
 
                     // Deadlock warning - the interface locks these same two -w-
                     // Make sure they're locked in the same order in both. Whoopsie.
@@ -1203,16 +1191,14 @@ fn listener(
                         // Unlock before long potentially long awaits.
                         drop(documents);
 
-                        let write = document_preview.write();
-                        let buf = write.get_writeable_buffer().await;
+                        let proxy = document_preview.write().await;
                         let commands =
-                            blend.blend(&renderer, buf, true, &blend_info, [0; 2], [0; 2])?;
-                        future
+                            blend.blend(&renderer, proxy.clone(), true, &blend_info, [0; 2], [0; 2])?;
+                        let fence = future
                             .then_execute(renderer.queues().compute().queue().clone(), commands)?
-                            .then_signal_fence_and_flush()?
-                            .await?;
-
-                        write.swap();
+                            .boxed_send()
+                            .then_signal_fence_and_flush()?;
+                        proxy.submit_with_fence(fence);
                     }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(num)) => {
@@ -1243,9 +1229,7 @@ fn main() -> AnyResult<std::convert::Infallible> {
     //let (image, future) = load_document_image(render_context.clone(), &std::path::PathBuf::from("/home/aspen/Pictures/thesharc.png"))?;
     //future.wait(None)?;
 
-    let document_view = Arc::new(parking_lot::RwLock::new(
-        document_viewport_proxy::DocumentViewportPreviewProxy::new(&render_surface)?,
-    ));
+    let document_view = Arc::new(document_viewport_proxy::DocumentViewportPreviewProxy::new(&render_surface)?);
     let window_renderer = window_surface.with_render_surface(
         render_surface,
         render_context.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1031,9 +1031,7 @@ static GLOBALS: std::sync::OnceLock<Globals> = std::sync::OnceLock::new();
 fn listener(
     mut event_stream: tokio::sync::broadcast::Receiver<stylus_events::StylusEventFrame>,
     renderer: Arc<render_device::RenderContext>,
-    document_preview: Arc<
-        document_viewport_proxy::DocumentViewportPreviewProxy,
-    >,
+    document_preview: Arc<document_viewport_proxy::DocumentViewportPreviewProxy>,
 ) -> AnyResult<()> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
@@ -1073,7 +1071,7 @@ fn listener(
             match event_stream.recv().await {
                 Ok(event_frame) => {
                     // Silly silly block_in_place. This will wait at most the time taken to write one pointer. >:V
-                    // Tokio will panic though in order to force good form. 
+                    // Tokio will panic though in order to force good form.
                     let matrix = document_preview.get_matrix().await.invert().unwrap();
 
                     // Deadlock warning - the interface locks these same two -w-
@@ -1194,8 +1192,14 @@ fn listener(
                         drop(documents);
 
                         let proxy = document_preview.write().await;
-                        let commands =
-                            blend.blend(&renderer, proxy.clone(), true, &blend_info, [0; 2], [0; 2])?;
+                        let commands = blend.blend(
+                            &renderer,
+                            proxy.clone(),
+                            true,
+                            &blend_info,
+                            [0; 2],
+                            [0; 2],
+                        )?;
                         let fence = future
                             .then_execute(renderer.queues().compute().queue().clone(), commands)?
                             .boxed_send()
@@ -1231,7 +1235,9 @@ fn main() -> AnyResult<std::convert::Infallible> {
     //let (image, future) = load_document_image(render_context.clone(), &std::path::PathBuf::from("/home/aspen/Pictures/thesharc.png"))?;
     //future.wait(None)?;
 
-    let document_view = Arc::new(document_viewport_proxy::DocumentViewportPreviewProxy::new(&render_surface)?);
+    let document_view = Arc::new(document_viewport_proxy::DocumentViewportPreviewProxy::new(
+        &render_surface,
+    )?);
     let window_renderer = window_surface.with_render_surface(
         render_surface,
         render_context.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1072,7 +1072,9 @@ fn listener(
         loop {
             match event_stream.recv().await {
                 Ok(event_frame) => {
-                    let matrix = document_preview.get_matrix().invert().unwrap();
+                    // Silly silly block_in_place. This will wait at most the time taken to write one pointer. >:V
+                    // Tokio will panic though in order to force good form. 
+                    let matrix = document_preview.get_matrix().await.invert().unwrap();
 
                     // Deadlock warning - the interface locks these same two -w-
                     // Make sure they're locked in the same order in both. Whoopsie.

--- a/src/window.rs
+++ b/src/window.rs
@@ -238,6 +238,11 @@ impl WindowRenderer {
                 Ok(r) => r,
             };
 
+        let commands = self.egui_ctx.build_commands(idx);
+
+        //Wait for previous frame to end. (required for safety of preview render proxy)
+        self.last_frame_fence.take().map(|fence| fence.wait(None));
+
         // Lmao
         // Free up resources from the last time this frame index was rendered
         // Todo: call much much sooner.
@@ -246,10 +251,6 @@ impl WindowRenderer {
             let preview_commands = self.preview_renderer.render(idx)?;
             preview_commands
         };
-        let commands = self.egui_ctx.build_commands(idx);
-
-        //Wait for previous frame to end.
-        self.last_frame_fence.take().map(|fence| fence.wait(None));
 
         let render_complete = match commands {
             Some((Some(transfer), draw)) => {

--- a/src/window.rs
+++ b/src/window.rs
@@ -134,7 +134,9 @@ impl WindowRenderer {
             use winit::event::{Event, WindowEvent};
 
             //Weird ownership problems here.
-            let Some(event) = event.to_static() else {return};
+            let Some(event) = event.to_static() else {
+                return;
+            };
             self.egui_ctx.push_winit_event(&event);
 
             match event {
@@ -247,8 +249,9 @@ impl WindowRenderer {
         // Free up resources from the last time this frame index was rendered
         // Todo: call much much sooner.
         let preview_commands = {
-            self.preview_renderer.render_complete(idx);
-            let preview_commands = self.preview_renderer.render(idx)?;
+            // Safety - we synchronize on the previous frame above.
+            // The commands from last render will be done now :3
+            let preview_commands = unsafe { self.preview_renderer.render(idx)? };
             preview_commands
         };
 


### PR DESCRIPTION
Cleans up the document proxy code, some of the yuckiest of the old hacked bits.
Nice RAII interface, much more async integrated, and now any internal synchronization should only be for a very short time. (~the duration of a pointer write).
...except one writer waiting on another, ofc :P