### PR TITLE
Async render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,7 +2080,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
+ "parking_lot",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.188", features = ["derive", "rc"] }
 smallvec = { version = "1.10.0", features = ["serde"] }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.40"
-tokio = { version = "1.28.2", features = ["sync", "rt" ] }
+tokio = { version = "1.28.2", features = ["sync", "rt", "macros", "parking_lot"] }
 try-block = "0.1.0"
 uuid = { version = "1.4.0", features = ["v4"] }
 vulkano = "0.33.0"

--- a/src/gpu_tess.rs
+++ b/src/gpu_tess.rs
@@ -181,6 +181,9 @@ impl GpuStampTess {
             .try_fold(0, u64::checked_add);
         let count = count.ok_or_else(|| anyhow::anyhow!("Packed point buffer too long!"))?;
 
+        if count == 0 {
+            anyhow::bail!("Tess invoked on zero points!")
+        }
         let packed_points = vk::Buffer::new_slice::<interface::InputStrokeVertex>(
             self.context.allocators().memory(),
             vk::BufferCreateInfo {
@@ -216,6 +219,9 @@ impl GpuStampTess {
         vk::Subbuffer<[interface::OutputStrokeVertex]>,
         vk::Subbuffer<[interface::OutputStrokeInfo]>,
     )> {
+        if strokes.is_empty() {
+            anyhow::bail!("Tess invoked on empty zero strokes!")
+        }
         let mut point_index_counter = 0;
         let mut group_index_counter = 0;
         let mut vertex_output_index_counter = 0;
@@ -263,6 +269,10 @@ impl GpuStampTess {
                 info
             }),
         )?;
+
+        if group_index_counter == 0 {
+            anyhow::bail!("Stroke too short to tessellate.")
+        }
         // One element per workgroup, telling it which info to work on.
         let input_map = vk::Buffer::new_slice::<u32>(
             self.context.allocators().memory(),

--- a/src/gpu_tess.rs
+++ b/src/gpu_tess.rs
@@ -169,7 +169,7 @@ impl GpuStampTess {
     /// Will automatically load stroke points into a buffer.
     pub fn tess(
         &self,
-        strokes: &[crate::ImmutableStroke],
+        strokes: &[crate::WeakStroke],
     ) -> anyhow::Result<(
         vulkano::sync::future::SemaphoreSignalFuture<impl vk::sync::GpuFuture>,
         vk::Subbuffer<[interface::OutputStrokeVertex]>,
@@ -209,7 +209,7 @@ impl GpuStampTess {
     /// Returns a semaphore for when the compute completes, the vertex buffer, and the draw indirection buffer.
     pub fn tess_buffer(
         &self,
-        strokes: &[crate::ImmutableStroke],
+        strokes: &[crate::WeakStroke],
         packed_points: vulkano::buffer::subbuffer::Subbuffer<[interface::InputStrokeVertex]>,
     ) -> anyhow::Result<(
         vulkano::sync::future::SemaphoreSignalFuture<impl vk::sync::GpuFuture>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1386,9 +1386,7 @@ async fn render_worker(
                 // <rerender viewport>
                 let blend_info: Vec<_> = {
                     let read = globals.documents.read().await;
-                    let Some(doc) =
-                        read.iter().find(|doc| doc.id.weak() == *new_document)
-                    else {
+                    let Some(doc) = read.iter().find(|doc| doc.id.weak() == *new_document) else {
                         // Document not found, nothin to draw.
                         continue;
                     };
@@ -1416,12 +1414,9 @@ async fn render_worker(
 
                 let fence = renderer
                     .now()
-                    .then_execute(
-                        renderer.queues().compute().queue().clone(),
-                        commands,
-                    )?
+                    .then_execute(renderer.queues().compute().queue().clone(), commands)?
                     .boxed_send()
-                .then_signal_fence_and_flush()?;
+                    .then_signal_fence_and_flush()?;
                 proxy.submit_with_fence(fence);
             }
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -48,7 +48,8 @@ impl WindowSurface {
             last_frame_fence: None,
             egui_ctx,
             preview_renderer,
-            action_collector: crate::actions::winit_action_collector::WinitKeyboardActionCollector::new(send),
+            action_collector:
+                crate::actions::winit_action_collector::WinitKeyboardActionCollector::new(send),
             action_stream: stream,
             stylus_events: Default::default(),
         })
@@ -149,7 +150,6 @@ impl WindowRenderer {
             };
             self.egui_ctx.push_winit_event(&event);
 
-
             match event {
                 Event::WindowEvent { event, .. } => {
                     self.action_collector.push_event(&event);
@@ -184,7 +184,7 @@ impl WindowRenderer {
                         }
                         _ => (),
                     }
-                },
+                }
                 Event::DeviceEvent { event, .. } => {
                     match event {
                         //Pressure out of 65535
@@ -206,7 +206,7 @@ impl WindowRenderer {
                         self.apply_platform_output(output);
                     };
 
-                    if self.egui_ctx.needs_redraw() {
+                    if self.egui_ctx.needs_redraw() || self.preview_renderer.has_update() {
                         self.window().request_redraw()
                     }
 
@@ -218,7 +218,9 @@ impl WindowRenderer {
                     };
                 }
                 Event::RedrawEventsCleared => {
-                    *control_flow = winit::event_loop::ControlFlow::Wait;
+                    *control_flow = winit::event_loop::ControlFlow::WaitUntil(
+                        std::time::Instant::now() + std::time::Duration::from_millis(100),
+                    );
                 }
                 _ => (),
             }


### PR DESCRIPTION
Previous implementation rendered immediately after collecting stylus input resulting in a mess of mixed logic for the two. Splits rendering into it's own cooperative thread alongside the input system :3

* Better performance, especially for cards with limited compute performance
   * Skips a lot of repeat tessellation by rendering new strokes onto a cached image of the old. Still todo: stepped caching and blend caching
* In the event that the render task gets stalled or cannot keep up, render commands are aggregated and 
 batched to help relieve strain.

Some parts are yet to be plumbed in - BlendChange and DocumentChange needs to be reported by the UI, which is currently not possible without a bunch of global state due to the way the UI is implemented.

Introduces a memory regression - 20MB are allocated upon first mouseover. In the grand scheme the memory usage is still tiny, but that 20MB represents ~1/4 the total footprint and it's just somewhere in the void :/