### PR TITLE
Document navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "try-block",
+ "ultraviolet",
  "uuid",
  "vulkano",
  "vulkano-shaders",
@@ -1800,6 +1801,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2202,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a464a4b34948a5f67fddd2b823c62d9d92e44be75058b99939eae6c5b6960b33"
 
 [[package]]
+name = "ultraviolet"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a28554d13eb5daba527cc1b91b6c341372a0ae45ed277ffb2c6fbc04f319d7e"
+dependencies = [
+ "bytemuck",
+ "wide",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2488,16 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "wide"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bytemuck = "1.13.1"
 cgmath = "0.18.0"
 dhat = { version = "0.3.2", optional = true }
 dirs = "5.0.1"
-egui = {version = "0.22.0", features = ["bytemuck"]}
+egui = { version = "0.22.0", features = ["bytemuck"] }
 env_logger = "0.10.0"
 image = "0.24.6"
 log = "0.4.18"
@@ -24,8 +24,14 @@ serde = { version = "1.0.188", features = ["derive", "rc"] }
 smallvec = { version = "1.10.0", features = ["serde"] }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.40"
-tokio = { version = "1.28.2", features = ["sync", "rt", "macros", "parking_lot"] }
+tokio = { version = "1.28.2", features = [
+    "sync",
+    "rt",
+    "macros",
+    "parking_lot",
+] }
 try-block = "0.1.0"
+ultraviolet = { version = "0.9.2", features = ["bytemuck"] }
 uuid = { version = "1.4.0", features = ["v4"] }
 vulkano = "0.33.0"
 vulkano-shaders = "0.33.0"

--- a/assumptions.md
+++ b/assumptions.md
@@ -1,6 +1,8 @@
-To ease development, for now several assumptions are made about the device. Of course, the plan will be to reduce reliance on these assumptions as development furthers. As I make these assumptions (and discover the ones I made prior to assembling this list :P ) I will notate them here in order to a) serve as a todo list of blockers for running on any device and b) figure out what's missing should I find a device which doesn't work.
+# Assumptions
+
+To ease development, several assumptions are made about the graphics device. Of course, the plan will be to reduce reliance on these assumptions as development furthers. As I make these assumptions (and discover the ones I made prior to assembling this list :P ) I will notate them here in order to both serve as a todo list of blockers for running on any device and to figure out what's missing should I find a device which doesn't work.
 
 * VK1.3 OR maintenance4 (workgroup size specialization)
-* dualSrcBlend (~100% on desktop)
-* dynamicRendering
-* multiDrawIndirect
+* dualSrcBlend (erasers) (~100% on desktop)
+* dynamicRendering (Pure laziness)
+* multiDrawIndirect (tessellated stroke draw batching)

--- a/readme.md
+++ b/readme.md
@@ -2,18 +2,22 @@
 
 Graphics accelerated vector-based paint program for people who like compositing software :3
 
-It doesn't do much more than let you scribble yet.
+In heavy development, many features are in-progress. But you can doodle to your heart's content!
 
-Platform support, in order of development priority:
-| **Platform**      | Pen input          | Pad input          |
-|-------------------|--------------------|--------------------|
-| Unix (Wayland)    |:white_large_square:|:white_large_square:|
-| Unix (Xorg)       |Partial             |None                 |
-| Windows (Ink)     |:white_large_square:|:white_large_square:|
-| Windows (wintab)  |:white_large_square:|:white_large_square:|
+## Building
+Requires the [most recent Rust nightly toolchain](https://www.rust-lang.org/tools/install). Clone this repo and execute `cargo run --release` from within the root directory of this repo!
+
+**Note the platform support below.** The app is fully cross platform and should run on any device (if not, please report) but tablet input is very much unfinished.
+
+| **Platform**      | Pen input   | Pad input   | Notes                              |
+|-------------------|-------------|-------------|------------------------------------|
+| Windows (Ink)     |None         |None         |                                    |
+| Unix (Xorg)       |Pressure only|None         |On wayland: `WINIT_UNIX_BACKEND=x11`|
+| Unix (Wayland)    |None         |None         |No universally supported tablet API |
+| Windows (wintab)  |None         |None         |Documentation tough to come accross |
 
 # Road to **0.2.0**
-To declare **0.2.0**, I would like to be able to somewhat freely draw a thing and save said thing to disk. Note-to-self: do so in a sustainable manner, such that completing 0.2.0 does not prevent me from developing 1.0.0, in both the burnout and technical debt sense :P
+To declare **0.2.0**, I would like to be able to freely doodle a thing and save it to disk. We're getting dangerously close!
 
  - [ ] File I/O
    - [ ] Read/Write custom vector image format
@@ -39,12 +43,13 @@ To declare **0.2.0**, I would like to be able to somewhat freely draw a thing an
    - [X] Initial layout
    - [X] A ~~simple~~ **✨robust and rebindable✨** hotkey system, with support for
          pen and pad buttons (although, pen+pad events are not yet reported)
-   - [ ] Infinite Undo/Redo
-   - [ ] Pan, Zoom, Scroll, Rotate, Mirror viewport
+   - [X] Infinite Undo/Redo
+   - [X] Pan, Zoom, Scroll, Rotate, Mirror viewport
    - [ ] Fit, 100% modes
 
 ## Long-term Goals
  * Support the "95%" GPU - For accessibility, this should work on low-end GPUs. Don't rely on overly niche vulkan extensions, but fall-forward on them if they provide sufficient benifit (eg, `EXT_mesh_shader`)
+    * Progress towards this goal is tracked in [assumptions.md](assumptions.md).
  * Survive extreme errors - recovery from swapchain, surface, device, or even window loss.
    * *No* important data should ever exist on the GPU alone - all buffers and images should be derived data.
  * Be able to run without a surface at all. For exporting files from command line.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -28,7 +28,7 @@ pub enum Action {
     LayerNew,
     LayerDelete,
 }
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ActionEvent {
     Press,
     /// The action was held long enough that the key is being strobed by the OS.
@@ -381,6 +381,9 @@ impl ActionFrame {
     fn fast_forward(&self) -> ActionStates {
         let mut future = self.base_state.clone();
         for (event, action) in self.actions.iter() {
+            if *event != ActionEvent::Repeat {
+                log::trace!("Action {action:?} {event:?}")
+            };
             future.push(*event, *action);
         }
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -21,6 +21,7 @@ pub enum Action {
 
     ViewportPan,
     ViewportScrub,
+    ViewportRotate,
     ViewportFlipHorizontal,
 
     LayerUp,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -13,7 +13,7 @@ pub mod hotkeys;
 pub mod winit_action_collector;
 
 #[derive(
-    serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, strum::AsRefStr, Clone, Copy, Debug
+    serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, strum::AsRefStr, Clone, Copy, Debug,
 )]
 pub enum Action {
     Undo,
@@ -103,16 +103,27 @@ pub fn create_action_stream() -> (ActionSender, ActionStream) {
     let (send, recv) = tokio::sync::broadcast::channel(32);
 
     let current_state = (ActionStates::default(), recv);
-    let current_state : std::sync::RwLock<_> = current_state.into();
+    let current_state: std::sync::RwLock<_> = current_state.into();
     let current_state = Arc::new(current_state);
 
-    (ActionSender{send, current_state: Arc::downgrade(&current_state) }, ActionStream{current_state})
+    (
+        ActionSender {
+            send,
+            current_state: Arc::downgrade(&current_state),
+        },
+        ActionStream { current_state },
+    )
 }
 
 pub struct ActionSender {
     // Weak, as we can stop carrying/updating this info when it stops being possible to create listeners
     // (ie, when the holder of the Arc is dropped)
-    current_state: std::sync::Weak<std::sync::RwLock<(ActionStates, tokio::sync::broadcast::Receiver<(ActionEvent, Action)>)>>,
+    current_state: std::sync::Weak<
+        std::sync::RwLock<(
+            ActionStates,
+            tokio::sync::broadcast::Receiver<(ActionEvent, Action)>,
+        )>,
+    >,
     send: tokio::sync::broadcast::Sender<(ActionEvent, Action)>,
 }
 impl ActionSender {
@@ -154,11 +165,15 @@ impl ActionSender {
 }
 
 pub struct ActionStream {
-    current_state: Arc<std::sync::RwLock<(ActionStates, tokio::sync::broadcast::Receiver<(ActionEvent, Action)>)>>,
+    current_state: Arc<
+        std::sync::RwLock<(
+            ActionStates,
+            tokio::sync::broadcast::Receiver<(ActionEvent, Action)>,
+        )>,
+    >,
 }
 impl ActionStream {
     pub fn listen(&self) -> ActionListener {
-
         // All is locked behind RwLock to prevent subtle race condition:
         // recv and current state are deeply intertwined, and
         // it's important that recv's "start" aligns with the exact moment
@@ -244,13 +259,13 @@ impl ActionListener {
                 Err(RecvError::Closed) => return Err(ListenError::Closed),
                 Err(RecvError::Lagged(..)) => {
                     self.poisoned = true;
-                    return Err(ListenError::Poisoned)
-                },
+                    return Err(ListenError::Poisoned);
+                }
             }
 
             // Then, try to recieve as many more as available without waiting.
             loop {
-                let recv =  self.recv.try_recv();
+                let recv = self.recv.try_recv();
 
                 use tokio::sync::broadcast::error::TryRecvError;
                 match recv {
@@ -354,7 +369,7 @@ impl ActionFrame {
             match event.0 {
                 ActionEvent::Press => is_held = true,
                 ActionEvent::Release => is_held = false,
-                ActionEvent::Repeat => (),
+                ActionEvent::Repeat => is_held = true,
                 ActionEvent::Shadowed => is_shadowed = true,
                 ActionEvent::Unshadowed => is_shadowed = false,
             }

--- a/src/actions/hotkeys.rs
+++ b/src/actions/hotkeys.rs
@@ -194,9 +194,9 @@ impl Default for ActionsToKeys {
             HotkeyCollection {
                 keyboard_hotkeys: Some(Arc::new([KeyboardHotkey {
                     alt: false,
-                    ctrl: true,
+                    ctrl: false,
                     shift: false,
-                    key: VirtualKeyCode::Space,
+                    key: VirtualKeyCode::S,
                 }])),
                 pad_hotkeys: None,
                 pen_hotkeys: None,
@@ -210,6 +210,19 @@ impl Default for ActionsToKeys {
                     ctrl: false,
                     shift: false,
                     key: VirtualKeyCode::M,
+                }])),
+                pad_hotkeys: None,
+                pen_hotkeys: None,
+            },
+        );
+        keys.insert(
+            super::Action::ViewportRotate,
+            HotkeyCollection {
+                keyboard_hotkeys: Some(Arc::new([KeyboardHotkey {
+                    alt: false,
+                    ctrl: false,
+                    shift: false,
+                    key: VirtualKeyCode::R,
                 }])),
                 pad_hotkeys: None,
                 pen_hotkeys: None,

--- a/src/document_viewport_proxy.rs
+++ b/src/document_viewport_proxy.rs
@@ -250,8 +250,6 @@ impl ProxySurfaceData {
                     view_transform::DocumentTransform::Transform(t) => t.clone(),
                 };
 
-                log::trace!("Xform: {transform:?}");
-
                 let base_xform = ultraviolet::Mat4::from_nonuniform_scale(ultraviolet::Vec3 {
                     x: crate::DOCUMENT_DIMENSION as f32,
                     y: crate::DOCUMENT_DIMENSION as f32,

--- a/src/document_viewport_proxy.rs
+++ b/src/document_viewport_proxy.rs
@@ -67,7 +67,7 @@ mod shaders {
             void main() {
                 uvec2 grid_coords = uvec2(gl_FragCoord.xy) / SIZE;
                 bool is_light = (grid_coords.x + grid_coords.y) % 2 == 0;
-                vec3 grid_color = vec3(vec3(is_light ? LIGHT : DARK));
+                vec3 grid_color = 1.0 - vec3(vec3(is_light ? LIGHT : DARK));
 
                 vec4 col = texture(image, uv);
                 // col is pre-multiplied, grid color is not. Combine!
@@ -635,6 +635,9 @@ impl DocumentViewportPreviewProxy {
             }
             crate::view_transform::DocumentTransform::Transform(t) => Some(t),
         }
+    }
+    pub fn get_viewport(&self) -> (cgmath::Point2<f32>, cgmath::Vector2<f32>) {
+        *self.viewport.read()
     }
 }
 impl PreviewRenderProxy for DocumentViewportPreviewProxy {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ pub use tess::StrokeTessellator;
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 /// Obviously will be user specified on a per-document basis, but for now...
-const DOCUMENT_DIMENSION: u32 = 512;
+const DOCUMENT_DIMENSION: u32 = 32;
 /// Premultiplied RGBA16F for interesting effects (negative + overbright colors and alpha) with
 /// more than 11bit per channel precision in the \[0,1\] range.
 /// Will it be user specified in the future?

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ pub use tess::StrokeTessellator;
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 /// Obviously will be user specified on a per-document basis, but for now...
-const DOCUMENT_DIMENSION: u32 = 32;
+const DOCUMENT_DIMENSION: u32 = 1080;
 /// Premultiplied RGBA16F for interesting effects (negative + overbright colors and alpha) with
 /// more than 11bit per channel precision in the \[0,1\] range.
 /// Will it be user specified in the future?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1599,7 +1599,7 @@ async fn stylus_event_collector(
                                 last_pos.map(|pos| (event.pos.0 - pos.0, event.pos.1 - pos.1))
                             {
                                 if is_scrub {
-                                    let scale = 1.0 + (delta.0 + delta.1) / 10.0;
+                                    let scale = 1.0 + (delta.0 + delta.1) / 100.0;
                                     let _ = transform.scale_about(
                                         cgmath::Point2 {
                                             x: start_pos.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1461,8 +1461,8 @@ async fn stylus_event_collector(
 
     let mut current_stroke = None::<Stroke>;
 
-    let mut last_pos = None::<(f32, f32)>;
     let mut drag_start_pos = None::<(f32, f32)>;
+    let mut initial_transform = None::<view_transform::ViewTransform>;
 
     loop {
         match event_stream.recv().await {
@@ -1591,49 +1591,63 @@ async fn stylus_event_collector(
 
                 if is_pan || is_scrub {
                     // treat stylus events as viewport movement
+                    let mut new_transform = None::<view_transform::ViewTransform>;
                     for event in event_frame.iter() {
                         if event.pressed {
+                            let initial_transform =
+                                initial_transform.get_or_insert(transform.clone());
                             let start_pos = drag_start_pos.get_or_insert(event.pos);
 
-                            if let Some(delta) =
-                                last_pos.map(|pos| (event.pos.0 - pos.0, event.pos.1 - pos.1))
-                            {
-                                if is_scrub {
-                                    let scale = 1.0 + (delta.0 + delta.1) / 100.0;
-                                    let _ = transform.scale_about(
+                            let delta = (event.pos.0 - start_pos.0, event.pos.1 - start_pos.1);
+                            if is_scrub {
+                                // Up or right is zoom in. This is natural for me as a right-handed
+                                // person, but might ask around and see if this should be adjustable.
+                                // certainly the speed should be :P
+                                let scale = 1.01f32.powf(delta.0 - delta.1);
+
+                                // Take the initial transform, and scale about the first drag point.
+                                // If the transform becomes broken (returns err), don't use it.
+                                let mut new = initial_transform.clone();
+                                if new
+                                    .scale_about(
                                         cgmath::Point2 {
                                             x: start_pos.0,
                                             y: start_pos.1,
                                         },
                                         scale,
-                                    );
-                                } else if is_pan {
-                                    transform.pan(cgmath::Vector2 {
-                                        x: delta.0,
-                                        y: delta.1,
-                                    });
-                                }
+                                    )
+                                    .is_ok()
+                                {
+                                    new_transform = Some(new);
+                                };
+                            } else if is_pan {
+                                let mut new = initial_transform.clone();
+                                new.pan(cgmath::Vector2 {
+                                    x: delta.0,
+                                    y: delta.1,
+                                });
+                                new_transform = Some(new);
                             }
-
-                            last_pos = Some(event.pos);
                         } else {
-                            last_pos = None;
+                            initial_transform = None;
                             drag_start_pos = None;
                         }
                     }
-                    document_preview
-                        .insert_document_transform(view_transform::DocumentTransform::Transform(
-                            transform,
-                        ))
-                        .await;
+                    // Set transform, if changed.
+                    if let Some(transform) = new_transform {
+                        document_preview
+                            .insert_document_transform(
+                                view_transform::DocumentTransform::Transform(transform),
+                            )
+                            .await;
+                    }
                 } else {
                     // clear out drag/pan data. stinky bad
-                    last_pos = None;
+                    initial_transform = None;
                     drag_start_pos = None;
 
                     // treat stylus as new strokes
                     for event in event_frame.iter() {
-                        last_pos = Some(event.pos);
                         if event.pressed {
                             // Get stroke-in-progress or start anew.
                             let this_stroke = current_stroke.get_or_insert_with(|| Stroke {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ pub mod id;
 pub mod render_device;
 pub mod stylus_events;
 pub mod tess;
+pub mod view_transform;
 use blend::{Blend, BlendMode};
 
 pub use id::{FuzzID, WeakID};
@@ -1491,11 +1492,16 @@ async fn stylus_event_collector(
                 }
 
                 let frame = action_listener.frame().ok();
-                let (key_undos, key_redos) = match frame {
-                    None => (0, 0),
+                let (key_undos, key_redos, is_pan, is_scrub, is_mirror) = match frame {
+                    None => (0, 0, false, false, false,),
                     Some(f) => (
                         f.action_trigger_count(actions::Action::Undo),
                         f.action_trigger_count(actions::Action::Redo),
+
+                        f.is_action_held(actions::Action::ViewportPan),
+                        f.is_action_held(actions::Action::ViewportScrub),
+                        // An odd number of mirror requests, we assume two mirror requests cancel out
+                        f.action_trigger_count(actions::Action::ViewportFlipHorizontal) % 2 == 1,
                     ),
                 };
 

--- a/src/view_transform.rs
+++ b/src/view_transform.rs
@@ -72,20 +72,13 @@ impl ViewTransform {
         view_center: cgmath::Point2<f32>,
         scale_by: f32,
     ) -> Result<(), TransformError> {
-        let local_center = self.unproject(view_center)?.to_vec();
+        // vec from mouse to top-left
+        let local_center = view_center.to_vec() - self.decomposed.disp;
 
-        // then scale. May result in an un-invertible matrix, but this will only be reported later.
-        self.decomposed.concat_self(&Decomposed2 {
-            scale: scale_by,
-            disp: Zero::zero(),
-            rot: One::one(),
-        });
-        // then translate back.
-        self.decomposed.concat_self(&Decomposed2 {
-            disp: -(scale_by - 1.0) * local_center,
-            rot: One::one(),
-            scale: 1.0,
-        });
+        // Scale, then adjust translation.
+        self.decomposed.scale *= scale_by;
+        // Scale that vec from mouse to top-left by the same factor.
+        self.decomposed.disp = view_center.to_vec() - (local_center * scale_by);
 
         Ok(())
     }

--- a/src/view_transform.rs
+++ b/src/view_transform.rs
@@ -72,19 +72,17 @@ impl ViewTransform {
         view_center: cgmath::Point2<f32>,
         scale_by: f32,
     ) -> Result<(), TransformError> {
-        //let local_center = self.unproject(view_center)?.to_vec();
-        let local_center = view_center.to_vec();
-        // Translate so that local center is at origin
-        self.decomposed.concat_self(&Decomposed2 {
-            disp: -1.0 * local_center,
-            rot: One::one(),
-            scale: 1.0,
-        });
+        let local_center = self.unproject(view_center)?.to_vec();
+
         // then scale. May result in an un-invertible matrix, but this will only be reported later.
-        self.decomposed.scale *= scale_by;
+        self.decomposed.concat_self(&Decomposed2 {
+            scale: scale_by,
+            disp: Zero::zero(),
+            rot: One::one(),
+        });
         // then translate back.
         self.decomposed.concat_self(&Decomposed2 {
-            disp: local_center,
+            disp: -(scale_by - 1.0) * local_center,
             rot: One::one(),
             scale: 1.0,
         });

--- a/src/view_transform.rs
+++ b/src/view_transform.rs
@@ -1,0 +1,192 @@
+use cgmath::prelude::*;
+
+type Decomposed2 = cgmath::Decomposed<cgmath::Vector2<f32>, cgmath::Basis2<f32>>;
+
+/// An affine transform for views. Includes offset, rotation, uniform scale, and horizontal flip.
+/// (vertical flipping can be achieved by horizontal flip and rotate 180*)
+#[derive(Clone)]
+pub struct ViewTransform {
+    // Marker flag for flipping on the x axis. cgmath::Decomposed cannot represent this.
+    // todo: keeping it simple by not implementing this yet.
+    // flip_x: bool,
+    decomposed: Decomposed2,
+}
+pub enum TransformError {
+    /// The transform cannot be inverted anymore, and has become useless.
+    /// Occurs if scale gets too close to zero.
+    Uninvertable,
+}
+impl ViewTransform {
+    /// Is the view flipped (determinate negative)?
+    /// Doesn't differentiate between horizontal and vertical flipping.
+    pub fn is_flipped(&self) -> bool {
+        false //self.flip_x
+    }
+    /// Flip the view horizontally about this center in viewspace such that the x-coordinate of the center
+    /// remains in the same spot in the viewport after rotating.
+    pub fn flip_x_about(&mut self, view_center: cgmath::Point2<f32>) {
+        let local_center = self.unproject(view_center);
+        todo!()
+        // transform such that center is at 0,0
+        // flip
+        // transform back
+        //todo!()
+    }
+    /// Rotate about this center in viewspace such that the center remains in the same spot in the viewport after rotating.
+    pub fn rotate_about(
+        &mut self,
+        view_center: cgmath::Point2<f32>,
+        rotate: cgmath::Rad<f32>,
+    ) -> Result<(), TransformError> {
+        let local_center = self.unproject(view_center)?.to_vec();
+        // Translate so that local center is at origin
+        self.decomposed.concat_self(&Decomposed2 {
+            disp: -1.0 * local_center,
+            rot: One::one(),
+            scale: 1.0,
+        });
+        // then rotate
+        self.decomposed.concat_self(&Decomposed2 {
+            disp: Zero::zero(),
+            rot: Rotation2::from_angle(rotate),
+            scale: 1.0,
+        });
+        // then translate back.
+        self.decomposed.concat_self(&Decomposed2 {
+            disp: local_center,
+            rot: One::one(),
+            scale: 1.0,
+        });
+
+        Ok(())
+    }
+    /// Scale about this center in viewspace such that the center remains in the same spot in the viewport after scaling.
+    pub fn scale_about(
+        &mut self,
+        view_center: cgmath::Point2<f32>,
+        scale_by: f32,
+    ) -> Result<(), TransformError> {
+        let local_center = self.unproject(view_center)?.to_vec();
+        // Translate so that local center is at origin
+        self.decomposed.concat_self(&Decomposed2 {
+            disp: -1.0 * local_center,
+            rot: One::one(),
+            scale: 1.0,
+        });
+        // then scale. May result in an un-invertible matrix, but this will only be reported later.
+        self.decomposed.scale *= scale_by;
+        // then translate back.
+        self.decomposed.concat_self(&Decomposed2 {
+            disp: local_center,
+            rot: One::one(),
+            scale: 1.0,
+        });
+
+        Ok(())
+    }
+    /// Pan by this displacement in viewspace.
+    pub fn pan(&mut self, delta: cgmath::Vector2<f32>) -> Result<(), TransformError> {
+        let local_delta = self
+            .decomposed
+            .inverse_transform_vector(delta)
+            .ok_or(TransformError::Uninvertable)?;
+
+        self.decomposed.disp += local_delta;
+
+        Ok(())
+    }
+    /// Convert this point in view space to local space
+    pub fn unproject(
+        &self,
+        view_point: cgmath::Point2<f32>,
+    ) -> Result<cgmath::Point2<f32>, TransformError> {
+        Ok(self
+            .decomposed
+            .inverse_transform()
+            .ok_or(TransformError::Uninvertable)?
+            .transform_point(view_point))
+    }
+    /// Convert this point in local space to view space
+    pub fn project(&self, local_point: cgmath::Point2<f32>) -> cgmath::Point2<f32> {
+        self.decomposed.transform_point(local_point)
+    }
+}
+
+impl From<ViewTransform> for cgmath::Matrix3<f32> {
+    fn from(value: ViewTransform) -> Self {
+        value.decomposed.into()
+    }
+}
+
+pub struct DocumentFit {
+    pub flip_x: bool,
+    pub rotation: cgmath::Rad<f32>,
+}
+
+impl DocumentFit {
+    /// Make a transform from the given document size and viewport rect (pos, size)
+    pub fn make_transform(
+        &self,
+        document_size: cgmath::Vector2<f32>,
+        (view_pos, view_size): (cgmath::Point2<f32>, cgmath::Vector2<f32>),
+    ) -> Option<ViewTransform> {
+        let widest_viewport_dimension = view_size.x.max(view_size.y);
+
+        // rotate two rays. These will give us the max bounds of the rotated document.
+        // probably a easier and less literal way to do this x3
+        let bottom_right_corner_ray = document_size / 2.0;
+        let bottom_left_corner_ray = {
+            let mut ray = document_size / 2.0;
+            ray.x *= -1.0;
+            ray
+        };
+
+        let rot_basis = cgmath::Basis2::from_angle(self.rotation);
+        let bottom_right_corner_ray = rot_basis.rotate_vector(bottom_right_corner_ray);
+        let bottom_left_corner_ray = rot_basis.rotate_vector(bottom_left_corner_ray);
+
+        let half_max_range = cgmath::vec2(
+            bottom_left_corner_ray
+                .x
+                .abs()
+                .max(bottom_right_corner_ray.x.abs()),
+            bottom_left_corner_ray
+                .y
+                .abs()
+                .max(bottom_right_corner_ray.y.abs()),
+        );
+
+        // new fitting rectangle for document after rotation.
+        let document_size = half_max_range * 2.0;
+
+        // Margin around document
+        const MARGIN: f32 = 0.0;
+        let document_max_dimension = document_size.x.max(document_size.y) + MARGIN;
+        let document_scale = widest_viewport_dimension / document_max_dimension;
+
+        if document_scale < 0.001 {
+            None
+        } else {
+            Some(ViewTransform {
+                decomposed: cgmath::Decomposed {
+                    scale: document_scale,
+                    rot: rot_basis,
+                    // Wrong vector, todo.
+                    disp: view_pos.to_vec(),
+                },
+            })
+        }
+    }
+}
+
+pub enum DocumentTransform {
+    /// Auto positioned and sized, with given flip and rotation, to fit into the viewport.
+    ///
+    /// Used in initial document state and zoom-fit state
+    Fit(DocumentFit),
+    // Opted out of a center state, which would pretty much only be if the user was in Fit state and
+    // used zoom control (eg. ctrl+plus) and then didn't move the viewport.
+    // That's wildly niche, just use custom transform instead UwU
+    /// User-defined transform, after a scrub or drag.
+    Transform(ViewTransform),
+}

--- a/src/view_transform.rs
+++ b/src/view_transform.rs
@@ -72,7 +72,8 @@ impl ViewTransform {
         view_center: cgmath::Point2<f32>,
         scale_by: f32,
     ) -> Result<(), TransformError> {
-        let local_center = self.unproject(view_center)?.to_vec();
+        //let local_center = self.unproject(view_center)?.to_vec();
+        let local_center = view_center.to_vec();
         // Translate so that local center is at origin
         self.decomposed.concat_self(&Decomposed2 {
             disp: -1.0 * local_center,
@@ -91,15 +92,8 @@ impl ViewTransform {
         Ok(())
     }
     /// Pan by this displacement in viewspace.
-    pub fn pan(&mut self, delta: cgmath::Vector2<f32>) -> Result<(), TransformError> {
-        let local_delta = self
-            .decomposed
-            .inverse_transform_vector(delta)
-            .ok_or(TransformError::Uninvertable)?;
-
-        self.decomposed.disp += local_delta;
-
-        Ok(())
+    pub fn pan(&mut self, delta: cgmath::Vector2<f32>) {
+        self.decomposed.disp += delta;
     }
     /// Convert this point in view space to local space
     pub fn unproject(

--- a/src/view_transform.rs
+++ b/src/view_transform.rs
@@ -84,14 +84,11 @@ impl ViewTransform {
         rotation: cgmath::Rad<f32>,
         scale: f32,
     ) -> Self {
-        let disp = view_center.to_vec() - (scale * document_size / 2.0);
+        let rot = cgmath::Basis2::from_angle(rotation);
+        let disp = view_center.to_vec() - scale * rot.rotate_vector(document_size / 2.0);
 
         Self {
-            decomposed: Decomposed2 {
-                rot: Rotation2::from_angle(rotation),
-                scale,
-                disp,
-            },
+            decomposed: Decomposed2 { rot, scale, disp },
         }
     }
 }
@@ -203,7 +200,7 @@ impl Default for DocumentFit {
     fn default() -> Self {
         Self {
             flip_x: false,
-            rotation: Zero::zero(),
+            rotation: cgmath::Rad(1.0),
         }
     }
 }

--- a/src/view_transform.rs
+++ b/src/view_transform.rs
@@ -90,7 +90,7 @@ impl ViewTransform {
             decomposed: Decomposed2 {
                 rot: Rotation2::from_angle(rotation),
                 scale,
-                disp, // todo
+                disp,
             },
         }
     }

--- a/src/vulkano_prelude.rs
+++ b/src/vulkano_prelude.rs
@@ -6,6 +6,9 @@ pub use vulkano::{
 
 //Types and such
 pub mod vk {
+    // import the correct coordinate space from ultraviolet
+    pub use ultraviolet::projection::lh_ydown as projection;
+
     pub use vulkano::{
         DeviceSize,
         buffer::{


### PR DESCRIPTION
Add zoom, rotate, pan controls. This was an uphill battle due to a multitude of tiny, sneaky bugs and fighting linear algebra libraries...
Fit transform mode is not plumbed in, but it is more-or-less implemented and is the default mode. But once you leave it it's not possible to get back into :P

This is important groundwork for upcoming Gizmos.

Todo: commit to switching to `ultraviolet` as the linear algebra package of choice, as currently there are many many mixed vector representations.